### PR TITLE
Re-insert lines to clean the log message

### DIFF
--- a/liblights/lights.c
+++ b/liblights/lights.c
@@ -193,7 +193,11 @@ static int write_leds(const struct led_config *led)
 
     ALOGV("%s: color=0x%08x, delay_on=%d, delay_off=%d, blink=%s",
           __func__, led->color, led->delay_on, led->delay_off, blink);
-
+    
+    /* Add '\n' here to make the above log message clean. */
+    blink[count] = '\n';
+    blink[count+1] = '\0';
+    
     pthread_mutex_lock(&g_lock);
     err = write_str(LED_BLINK_NODE, blink);
     pthread_mutex_unlock(&g_lock);


### PR DESCRIPTION
Seems that the fast blinking notification LEDs experienced on some Samsung devices was due to the removal of these two lines that clean the 'blink' array. Propose re-adding to correct the fast blinking LED issue.