### PR TITLE
mkdtbimg.c: Add pagefile size option in usage

### DIFF
--- a/dtbhtool/mkdtbimg.c
+++ b/dtbhtool/mkdtbimg.c
@@ -44,6 +44,7 @@ int usage(void)
     fprintf(stderr,"usage: mkdtimg\n"
             "       --dt_dir <dtb path>\n"
             "       -o|--output <filename>\n"
+            "       -s <pagefile size>\n"
             );
     return 1;
 }


### PR DESCRIPTION
I wanted to build the kernel w/o android build system, so I compiled this mkdtbimg standalone. But when I tried to use it, the output dt.img was empty. So I looked at the source code, and the pagefile size of the kernel was required as option -s, but no reference in usage. This commit will add that usage